### PR TITLE
bromine 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ def note_printer(note: dict) -> None:
             reactionid = reactionid[:-3] + ":"
         reactions.append(f"({reactionid}, {val})")
     if len(reactions) != 0:
-        print("リアクション達: ", ", ".join(reactions))
+        print("リアクション: ", ", ".join(reactions))
 
     print("-"*NOBASIBOU_LENGTH)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # BromineCore
-[ぶろみね](https://github.com/35enidoi/bromine35bot)くんのコア部分の実装、misskeyのwebsocketAPI単体の実装です。  
+MisskeyのWebsocketAPI単体の実装です。  
 
-ローカルのノートを講読したり、通知を取得したり。リバーシbotも頑張れば実装できます。  
+ノートを講読したり、通知を取得したり。リバーシbotも頑張れば実装できます。  
 
-何か問題が発生したり追加してほしい機能があったらissueに書いてください  
-頑張って実装したり解決します
 # Example
 簡単なタイムライン閲覧クライアントです。  
 トークン無しでタイムラインをリアルタイムで閲覧できます。
@@ -15,15 +13,17 @@ from brcore import Bromine, enum
 
 INSTANCE = "misskey.io"
 TL = enum.MisskeyChannelNames.LOCAL_TIMELINE
-TL_ARGS = enum.MisskeyChannelArgs.LocalTimeline()  # 実際のところ引数はいらないので、空の辞書になっている
+TL_ARGS = enum.MisskeyChannelArgs.LocalTimeline()
 
 
 def note_printer(note: dict) -> None:
-    """ノートの情報を受け取って表示する関数"""
+    """ノートの情報を受け取って描画する関数"""
     NOBASIBOU_LENGTH = 20
     user = note["user"]
     username = user["name"] if user["name"] is not None else user["username"]
+
     print("-"*NOBASIBOU_LENGTH)
+
     if note.get("renoteId") and note["text"] is None:
         # リノートのときはリノート先だけ書く
         print(f"{username}がリノート")
@@ -34,12 +34,14 @@ def note_printer(note: dict) -> None:
         return
     else:
         # 普通のノート
-        print(f"{username}がノート ノートid: {note['id']}")
+        print(f"{username}が投稿しました。 noteid: {note['id']}")
+
     if note.get("reply"):
         # リプライがある場合
         print("リプライ:")
         note_printer(note["reply"])
     if note.get("text"):
+        # 本文
         print("テキスト:")
         print(note["text"])
     if note.get("renoteId"):
@@ -49,24 +51,23 @@ def note_printer(note: dict) -> None:
     if len(note["files"]) != 0:
         # ファイルがある時
         print(f"ファイル数: {len(note['files'])}")
+
     # リアクションとかを書く
     print(f"リプライ数: {note['repliesCount']}, リノート数: {note['renoteCount']}, リアクション数: {note['reactionCount']}")
+
     reactions = []
     for reactionid, val in note["reactions"].items():
         if reactionid[-3:] == "@.:":
-            # ローカルのカスタム絵文字のidはへんなのついてるので
-            # それを消す
+            # ローカルのカスタム絵文字のidはへんなのついてるので消す
             reactionid = reactionid[:-3] + ":"
         reactions.append(f"({reactionid}, {val})")
     if len(reactions) != 0:
         print("リアクション達: ", ", ".join(reactions))
+
     print("-"*NOBASIBOU_LENGTH)
 
 
 async def note_async(note: dict) -> None:
-    """上のprinterの引数を調整するやつ
-
-    asyncにするのはws_connectでは非同期関数が求められるので(見た目非同期っていう体にしているだけ)"""
     note_printer(note["body"])
     print()  # 空白をノート後に入れておく
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ INSTANCE = "misskey.io"
 TL = enum.MisskeyChannelNames.LOCAL_TIMELINE
 TL_ARGS = enum.MisskeyChannelArgs.LocalTimeline()
 
+brm = Bromine(instance=INSTANCE)
+
 
 def note_printer(note: dict) -> None:
     """ノートの情報を受け取って描画する関数"""
@@ -67,21 +69,20 @@ def note_printer(note: dict) -> None:
     print("-"*NOBASIBOU_LENGTH)
 
 
+@brm.ws_connect_deco(TL, **TL_ARGS)
 async def note_async(note: dict) -> None:
     note_printer(note["body"])
     print()  # 空白をノート後に入れておく
 
 
-async def main() -> None:
-    brm = Bromine(instance=INSTANCE)
-    brm.ws_connect(TL, note_async, **TL_ARGS)
-    print("start...")
-    await brm.main()
+# デコレータを使わない場合は、下のように書くこともできる
+# brm.ws_connect(TL, note_async, **TL_ARGS)
 
 
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        print("start...")
+        asyncio.run(brm.main())
     except KeyboardInterrupt:
         print("fin")
 

--- a/brcore/core.py
+++ b/brcore/core.py
@@ -566,7 +566,7 @@ class Bromine:
 
         self.__log(f"unsubscribe note. id: {noteid}")
 
-    def ws_connect_deco(self, channel: str):
+    def ws_connect_deco(self, channel: str, id: Optional[str] = None, **params: Any):
         """ws_connectのデコレーター版
 
         Parameters
@@ -581,7 +581,7 @@ class Bromine:
             raise TypeError(ExceptionTexts.DECO_ARG_INVALID)
 
         def _wrap(func: Callable[[dict[str, Any]], Coroutine[Any, Any, None]]):
-            self.ws_connect(channel=channel, func=func)
+            self.ws_connect(channel=channel, func=func, id=id, **params)
             return func
 
         return _wrap
@@ -602,7 +602,7 @@ class Bromine:
 
         return _wrap
 
-    def add_comeback_deco(self, block: bool = False):
+    def add_comeback_deco(self, block: bool = False, id: Optional[str] = None):
         """add_comebackのデコレーター版
 
         Parameters
@@ -615,7 +615,7 @@ class Bromine:
             raise TypeError(ExceptionTexts.DECO_ARG_INVALID)
 
         def _wrap(func: Callable[[], Coroutine[Any, Any, None]]):
-            self.add_comeback(func=func, block=block)
+            self.add_comeback(func=func, block=block, id=id)
             return func
 
         return _wrap

--- a/brcore/core.py
+++ b/brcore/core.py
@@ -22,8 +22,6 @@ __all__ = ["Bromine"]
 class Bromine:
     """misskeyのwebsocketAPIを使いやすくしたクラス
 
-    websocketの実装を一々作らなくても簡単にwebsocketの通信ができるようになります
-
     Parameters
     ----------
     instance: str
@@ -81,7 +79,7 @@ class Bromine:
 
     @property
     def cooltime(self) -> int:
-        """websocketの接続が切れた時に再接続まで待つ時間"""
+        """websocketの接続が切れた時に再接続まで待つ時間(秒)"""
         return self.__COOL_TIME
 
     @cooltime.setter
@@ -89,7 +87,7 @@ class Bromine:
         if time > 0:
             self.__COOL_TIME = time
         else:
-            ValueError("負の値です")
+            raise ValueError("負の値です")
 
     @property
     def is_running(self) -> bool:
@@ -100,7 +98,7 @@ class Bromine:
     def expect_info_func(self) -> Callable[[dict[str, Any]], Coroutine[Any, Any, None]] | None:
         """謎の場所からくる情報を受け取る非同期関数
 
-        普通は特に設定しなくてもよい"""
+        絵文字の検出等に使用可能"""
         return self.__expect_info_func
 
     @expect_info_func.setter
@@ -236,12 +234,12 @@ class Bromine:
                      func: Callable[[], Coroutine[Any, Any, None]],
                      block: bool = False,
                      id: Optional[str] = None) -> str:
-        """comebackを作る関数
+        """再接続する際に自動で実行される関数をバインドする関数
 
         Parameters
         ----------
         func: CoroutineFunction
-            comeback時に実行する非同期関数
+            再接続時に実行する非同期関数
         block: bool, default False
             websocketとの交信をブロッキングして実行するか
         id: :obj:`str`, optional
@@ -280,7 +278,7 @@ class Bromine:
         return id
 
     def del_comeback(self, id: str) -> None:
-        """comeback消すやつ
+        """comebackを消すやつ
 
         Parameters
         ----------
@@ -311,7 +309,7 @@ class Bromine:
             self._ws_send(i[0], body)
 
     def _add_ws_reconnect(self, type: str, id: str, body: dict[str, Any]) -> None:
-        """接続しなおした時に再接続(情報を送る)する物を追加する
+        """接続しなおした時に再接続(情報を送る)する情報を追加する
 
         これは低レベルAPIなので普通は触らなくても大丈夫です。
 
@@ -340,7 +338,7 @@ class Bromine:
         self.__ws_on_comebacks[(type, id)] = body
 
     def _del_ws_reconnect(self, type: str, id: str) -> None:
-        """接続しなおした時に再接続(情報を送る)する物を削除する
+        """接続しなおした時に再接続(情報を送る)する情報を削除する
 
         これは低レベルAPIなので普通は触らなくても大丈夫です。
 
@@ -361,7 +359,7 @@ class Bromine:
             raise ValueError(ExceptionTexts.TYPE_AND_ID_INVALID)
 
     def _add_ws_type_id(self, type: str, id: str, func: Callable[[dict[str, Any]], Coroutine[Any, Any, None]]) -> None:
-        """websocketの情報を振り分ける辞書に追加する
+        """websocketの情報を振り分ける辞書に登録する
 
         これは低レベルAPIなので普通は触らなくても大丈夫です。
 
@@ -449,7 +447,7 @@ class Bromine:
                    func: Callable[[dict[str, Any]], Coroutine[Any, Any, None]],
                    id: Optional[str] = None,
                    **params: Any) -> str:
-        """channelに接続する関数
+        """チャンネルに接続する関数
 
         Parameters
         ----------
@@ -502,7 +500,7 @@ class Bromine:
         return id
 
     def ws_disconnect(self, id: str) -> None:
-        """チャンネルを接続解除する関数
+        """チャンネルから接続解除する関数
 
         Parameters
         ----------
@@ -528,8 +526,9 @@ class Bromine:
         Parameters
         ----------
         noteid: str
-            キャプチャするノートID
+            キャプチャするノートのID
         func: CoroutineFunction
+            反応があった時に実行される非同期関数
 
         Raises
         ------

--- a/brcore/core.py
+++ b/brcore/core.py
@@ -208,11 +208,11 @@ class Bromine:
                     wsd.cancel()
                     try:
                         await wsd
-                    except (
-                        asyncio.CancelledError,
-                        websockets.ConnectionClosed,
-                        websockets.InvalidStatus
-                    ):
+except (
+    asyncio.CancelledError,
+    websockets.ConnectionClosed,
+    websockets.exceptions.InvalidStatus,
+):
                         # とりあえず捻り潰す
                         pass
                     wsd = None

--- a/brcore/core.py
+++ b/brcore/core.py
@@ -4,6 +4,7 @@ import uuid
 import logging
 from functools import partial
 from typing import Any, Callable, NoReturn, Optional, Union, Coroutine
+from inspect import iscoroutinefunction
 
 import websockets
 
@@ -104,7 +105,7 @@ class Bromine:
 
     @expect_info_func.setter
     def expect_info_func(self, func: Callable[[dict[str, Any]], Coroutine[Any, Any, None]]) -> None:
-        if not asyncio.iscoroutinefunction(func):
+        if not iscoroutinefunction(func):
             raise TypeError(ExceptionTexts.FUNCTION_NOT_COROUTINEFUNC)
         self.__expect_info_func = func
 
@@ -280,7 +281,7 @@ class Bromine:
         else:
             if id in self.__on_comebacks:
                 raise ValueError(ExceptionTexts.ID_ALREADY_RESERVED)
-        if not asyncio.iscoroutinefunction(func):
+        if not iscoroutinefunction(func):
             raise TypeError(ExceptionTexts.FUNCTION_NOT_COROUTINEFUNC)
 
         self.__on_comebacks[id] = (block, func)
@@ -396,7 +397,7 @@ class Bromine:
         idが`ALLMATCH`の場合、ワイルドカード(type情報に一致する、他の識別idに引っかからなかった情報)になります。
 
         ワイルドカードは、id情報が存在しない場合にも振り分けられます。(emojiAdded等)"""
-        if not asyncio.iscoroutinefunction(func):
+        if not iscoroutinefunction(func):
             # 関数が非同期関数じゃない時
             raise TypeError(ExceptionTexts.FUNCTION_NOT_COROUTINEFUNC)
 

--- a/brcore/core.py
+++ b/brcore/core.py
@@ -217,7 +217,12 @@ class Bromine:
                     wsd.cancel()
                     try:
                         await wsd
-                    except asyncio.CancelledError:
+                    except (
+                        asyncio.CancelledError,
+                        websockets.ConnectionClosed,
+                        websockets.InvalidStatus
+                    ):
+                        # とりあえず捻り潰す
                         pass
                     wsd = None
                 if comebacks is not None:

--- a/brcore/core.py
+++ b/brcore/core.py
@@ -132,8 +132,6 @@ class Bromine:
 
     async def __runner(self, background_tasks: BackgroundTasks) -> NoReturn:
         """websocketとの交信を行うメインdaemon"""
-        # 何回連続で接続に失敗したかのカウンター
-        connect_fail_count = 0
         # この変数たちは最初に接続失敗すると未定義になるから保険のため
         # websocket_daemon(__ws_send_d)
         wsd: Union[None, asyncio.Task] = None
@@ -164,8 +162,6 @@ class Bromine:
                     # 送るdaemonの作成
                     wsd = asyncio.create_task(self.__ws_send_d(ws))
 
-                    # 接続に成功したということでfail_countを0に
-                    connect_fail_count = 0
                     while True:
                         # データ受け取り
                         data = json.loads(await ws.recv())
@@ -187,31 +183,27 @@ class Bromine:
 
             except asyncio.exceptions.TimeoutError as e:
                 # 接続がタイムアウトしたとき
-                self.__log(f"error occured: Timeout {e}")
-                await self.__runner_exception_wait(connect_fail_count)
+                await self.__runner_exception_wait(f"Timeout error: {e}")
 
             except websockets.ConnectionClosed as e:
                 # websocketが勝手に切れたりしたとき
-                self.__log(f"error occured: Websocket Error [{e}]")
-                await self.__runner_exception_wait(connect_fail_count)
+                await self.__runner_exception_wait(f"Websocket closed: {e}")
 
             except websockets.exceptions.InvalidStatus as e:
                 # ステータスコードが変な時
                 status_code = e.response.status_code
-                self.__log(f"error occured: Invalid Status Code [{status_code}]")
                 if status_code // 100 == 4:
                     # 400番台
                     raise e
                 else:
-                    await self.__runner_exception_wait(connect_fail_count)
+                    await self.__runner_exception_wait(f"Invalid status code: {status_code}")
 
             except Exception as e:
                 # 予定外のエラー発生時。
-                self.__log(f"fatal Error: {type(e)}, args: {e.args}")
+                self.__log(f"Fatal Error: {type(e)}, args: {e.args}")
                 raise e
 
             finally:
-                connect_fail_count += 1  # ここが処理されるのは何か例外が起きたときなので
                 # 再接続する際、いろいろ初期化する
                 if isinstance(wsd, asyncio.Task):
                     # __ws_send_dを止める
@@ -235,13 +227,10 @@ class Bromine:
                         pass
                     comebacks = None
 
-    async def __runner_exception_wait(self, fail_count: int) -> None:
+    async def __runner_exception_wait(self, error_message: str) -> None:
+        """__runner内でエラーが起きたときに再接続まで待つやつ"""
+        self.__log(f"Error occured: {error_message}. wait for {self.__COOL_TIME} seconds to reconnect.")
         await asyncio.sleep(self.__COOL_TIME)
-        if fail_count > 5:
-            # Todo: 例外投げるべき？
-            #       死にすぎてる～っていう例外を投げるようにする設定を追加するべき？
-            #       現状30秒寝る
-            await asyncio.sleep(30)
 
     def add_comeback(self,
                      func: Callable[[], Coroutine[Any, Any, None]],
@@ -492,7 +481,7 @@ class Bromine:
         また、idの指定がない場合、uuid4で自動生成されます"""
         if id is None:
             # idがなかったら自動生成
-            id = str(uuid.uuid4())
+            id = uuid.uuid4().hex
 
         body = {
             "channel": channel,

--- a/brcore/core.py
+++ b/brcore/core.py
@@ -3,7 +3,7 @@ import asyncio
 import uuid
 import logging
 from functools import partial
-from typing import Any, Callable, NoReturn, Optional, Union, Coroutine
+from typing import Any, Callable, NoReturn, Optional, Coroutine
 from inspect import iscoroutinefunction
 
 import websockets
@@ -97,7 +97,7 @@ class Bromine:
         return self.__is_running
 
     @property
-    def expect_info_func(self) -> Union[Callable[[dict[str, Any]], Coroutine[Any, Any, None]], None]:
+    def expect_info_func(self) -> Callable[[dict[str, Any]], Coroutine[Any, Any, None]] | None:
         """謎の場所からくる情報を受け取る非同期関数
 
         普通は特に設定しなくてもよい"""
@@ -134,9 +134,9 @@ class Bromine:
         """websocketとの交信を行うメインdaemon"""
         # この変数たちは最初に接続失敗すると未定義になるから保険のため
         # websocket_daemon(__ws_send_d)
-        wsd: Union[None, asyncio.Task] = None
+        wsd: None | asyncio.Task = None
         # comebacks(asyncio.gather)
-        comebacks: Union[None, asyncio.Future] = None
+        comebacks: None | asyncio.Future = None
 
         while True:
             try:

--- a/brcore/core.py
+++ b/brcore/core.py
@@ -26,9 +26,9 @@ class Bromine:
     ----------
     instance: str
         インスタンス名
-    token: :obj:`str`, optional
+    token: `str`, optional
         トークン
-    secure_connect: :obj:`bool`, default True
+    secure_connect: `bool`, default True
         セキュアな接続をするかどうか
 
         これはローカルで構築したインスタンス等セキュアな接続が
@@ -242,7 +242,7 @@ class Bromine:
             再接続時に実行する非同期関数
         block: bool, default False
             websocketとの交信をブロッキングして実行するか
-        id: :obj:`str`, optional
+        id: `str`, optional
             識別id、ない場合自動生成される
 
         Returns
@@ -455,7 +455,7 @@ class Bromine:
             チャンネル名
         func: CoroutineFunction
             反応があった時に実行される非同期関数
-        id: :obj:`str`, optional
+        id: `str`, optional
             識別id、もし指定されていない場合、自動生成される
         **params: Any
             接続する際のパラメーター
@@ -572,7 +572,11 @@ class Bromine:
         Parameters
         ----------
         channel: str
-            チャンネル名"""
+            チャンネル名
+        id: `str`, optional
+            識別id、もし指定されていない場合、自動生成される
+        **params: Any
+            接続する際のパラメーター"""
         if not isinstance(channel, str):
             raise TypeError(ExceptionTexts.DECO_ARG_INVALID)
 
@@ -603,8 +607,10 @@ class Bromine:
 
         Parameters
         ----------
-        block: :obj:`bool`, default False
-            websocketとの交信をブロッキングして実行するか"""
+        block: `bool`, default False
+            websocketとの交信をブロッキングして実行するか
+        id: `str`, optional
+            識別id、もし指定されていない場合、自動生成される"""
         if not isinstance(block, bool):
             raise TypeError(ExceptionTexts.DECO_ARG_INVALID)
 

--- a/brcore/core.py
+++ b/brcore/core.py
@@ -227,7 +227,7 @@ except (
 
     async def __runner_exception_wait(self, error_message: str) -> None:
         """__runner内でエラーが起きたときに再接続まで待つやつ"""
-        self.__log(f"Error occured: {error_message}. wait for {self.__COOL_TIME} seconds to reconnect.")
+self.__log(f"Error occurred: {error_message}. wait for {self.__COOL_TIME} seconds to reconnect.")
         await asyncio.sleep(self.__COOL_TIME)
 
     def add_comeback(self,

--- a/brcore/core.py
+++ b/brcore/core.py
@@ -208,11 +208,11 @@ class Bromine:
                     wsd.cancel()
                     try:
                         await wsd
-except (
-    asyncio.CancelledError,
-    websockets.ConnectionClosed,
-    websockets.exceptions.InvalidStatus,
-):
+                    except (
+                        asyncio.CancelledError,
+                        websockets.ConnectionClosed,
+                        websockets.exceptions.InvalidStatus,
+                    ):
                         # とりあえず捻り潰す
                         pass
                     wsd = None
@@ -227,7 +227,7 @@ except (
 
     async def __runner_exception_wait(self, error_message: str) -> None:
         """__runner内でエラーが起きたときに再接続まで待つやつ"""
-self.__log(f"Error occurred: {error_message}. wait for {self.__COOL_TIME} seconds to reconnect.")
+        self.__log(f"Error occurred: {error_message}. wait for {self.__COOL_TIME} seconds to reconnect.")
         await asyncio.sleep(self.__COOL_TIME)
 
     def add_comeback(self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,10 @@ requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "1.1"
+version = "1.2"
 name = "brominecore"
 dependencies = [
-    "websockets",
-    "typing-extensions"
+    "websockets"
 ]
 requires-python = ">= 3.10"
 authors = [
@@ -16,7 +15,7 @@ authors = [
 maintainers = [
     {name = "iodine53"},
 ]
-description = "Misskey websocketAPI wrapper."
+description = "Misskey WebsocketAPI wrapper."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "MIT License"}
 keywords = ["misskey"]
@@ -28,6 +27,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 websockets==15.0.1
-typing-extensions==4.14.0


### PR DESCRIPTION
#25 websocketの情報送信部分のエラーハンドリングを強化しました。

デコレータ版の関数に引数を追加しました。これにより、追加の引数が必要なチャンネル(例えばチャンネルチャンネル等)にも対応しました。

readmeやdocstringの内容を少し変更しました。

websocketに何回も再接続を試みる場合、前バージョンまでは5回目以降30秒固定で待つ仕様がありましたが、今回のバージョンからこの仕様は削除されました。
これからは何回も再接続を試みる場合においても固定で`cooltime`変数の値分待つことになります。(デフォルトは5秒)